### PR TITLE
Fix FFmpeg discovery and filter graph generation

### DIFF
--- a/talks_reducer/ffmpeg.py
+++ b/talks_reducer/ffmpeg.py
@@ -6,6 +6,7 @@ import os
 import re
 import subprocess
 import sys
+from shutil import which as _shutil_which
 from typing import List, Optional, Tuple
 
 from .progress import ProgressReporter, TqdmProgressReporter
@@ -13,6 +14,12 @@ from .progress import ProgressReporter, TqdmProgressReporter
 
 class FFmpegNotFoundError(RuntimeError):
     """Raised when FFmpeg cannot be located on the current machine."""
+
+
+def shutil_which(cmd: str) -> Optional[str]:
+    """Wrapper around :func:`shutil.which` for easier testing."""
+
+    return _shutil_which(cmd)
 
 
 def find_ffmpeg() -> Optional[str]:
@@ -272,9 +279,13 @@ def build_video_commands(
     return command_str, fallback_command_str, use_cuda_encoder
 
 
-def shutil_which(cmd: str) -> Optional[str]:
-    """Wrapper around :func:`shutil.which` for easier testing."""
-
-    from shutil import which as _which
-
-    return _which(cmd)
+__all__ = [
+    "FFmpegNotFoundError",
+    "find_ffmpeg",
+    "get_ffmpeg_path",
+    "check_cuda_available",
+    "run_timed_ffmpeg_command",
+    "build_extract_audio_command",
+    "build_video_commands",
+    "shutil_which",
+]

--- a/talks_reducer/pipeline.py
+++ b/talks_reducer/pipeline.py
@@ -203,7 +203,8 @@ def speed_up_video(
         if options.small:
             filter_parts.append("scale=-2:720")
         filter_parts.append(f"fps=fps={frame_rate}")
-        filter_parts.append(f'setpts={expression.replace(",", "\\,")}')
+        escaped_expression = expression.replace(",", "\\,")
+        filter_parts.append(f"setpts={escaped_expression}")
         filter_graph_file.write(",".join(filter_parts))
 
     command_str, fallback_command_str, use_cuda_encoder = build_video_commands(


### PR DESCRIPTION
## Summary
- ensure the FFmpeg helper resolves binaries without NameError by providing a module-level wrapper for shutil.which
- update the filter graph generation to escape expressions without triggering f-string syntax errors

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68e268e19b20832cbf01ade6c4374323