### PR TITLE
Grant release workflow permission to publish releases

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,8 @@
 name: CI
 
+permissions:
+  contents: write
+
 on:
   push:
     branches: [master]


### PR DESCRIPTION
## Summary
- add a workflow permissions block that grants contents: write so the release job can publish releases

## Testing
- not run (GitHub Actions workflow execution unavailable in this environment)

------
https://chatgpt.com/codex/tasks/task_e_68e29e71feb0832c8cc41a01b1688b6d