### PR TITLE
Fix Windows GUI packaging

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -71,9 +71,7 @@ jobs:
 
       - name: Prepare artifact name
         run: |
-          if [[ "${{ matrix.os }}" == "windows-latest" ]]; then
-            mv dist/talks-reducer-gui.exe dist/talks-reducer-gui-windows-amd64.exe
-          else
+          if [[ "${{ matrix.os }}" == "macos-latest" ]]; then
             mv dist/talks-reducer-gui dist/talks-reducer-gui-macos-universal
           fi
         shell: bash

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,6 +61,9 @@ jobs:
 
       - name: Build PyInstaller binary
         run: |
+          if [[ "${{ matrix.os }}" == "macos-latest" ]]; then
+            export MACOSX_DEPLOYMENT_TARGET=10.13
+          fi
           pyinstaller talks_reducer/gui.py \
             --name talks-reducer-gui \
             --onefile \

--- a/README.md
+++ b/README.md
@@ -8,7 +8,10 @@ project was renamed from **jumpcutter** to emphasize its focus on conference tal
 - 1h 19m, 171 MB — Talks Reducer `--small`
 
 ## Install GUI (Windows, macOS)
-Go to the [releases page](https://github.com/popstas/talks-reducer/releases) and download the appropriate `talks-reducer-gui-<platform>` artifact.
+Go to the [releases page](https://github.com/popstas/talks-reducer/releases) and download the appropriate artifact:
+
+- **Windows** — `talks-reducer-gui.exe`
+- **macOS** — `talks-reducer-gui-macos-universal`
 
 ## Install CLI (Linux, Windows, macOS)
 ```

--- a/README.md
+++ b/README.md
@@ -11,7 +11,8 @@ project was renamed from **jumpcutter** to emphasize its focus on conference tal
 Go to the [releases page](https://github.com/popstas/talks-reducer/releases) and download the appropriate artifact:
 
 - **Windows** — `talks-reducer-gui.exe`
-- **macOS** — `talks-reducer-gui-macos-universal`
+- **macOS** — `talks-reducer-gui-macos-universal` (requires macOS 10.13 High Sierra or
+  newer)
 
 ## Install CLI (Linux, Windows, macOS)
 ```

--- a/talks_reducer/gui.py
+++ b/talks_reducer/gui.py
@@ -11,11 +11,25 @@ from pathlib import Path
 from tkinter import filedialog, messagebox, ttk
 from typing import Callable, Iterable, List, Optional
 
-from .cli import gather_input_files
-from .ffmpeg import FFmpegNotFoundError
-from .models import ProcessingOptions
-from .pipeline import speed_up_video
-from .progress import ProgressHandle, SignalProgressReporter
+try:
+    from .cli import gather_input_files
+    from .ffmpeg import FFmpegNotFoundError
+    from .models import ProcessingOptions
+    from .pipeline import speed_up_video
+    from .progress import ProgressHandle, SignalProgressReporter
+except ImportError:  # pragma: no cover - handled at runtime
+    if __package__ not in (None, ""):
+        raise
+
+    PACKAGE_ROOT = Path(__file__).resolve().parent.parent
+    if str(PACKAGE_ROOT) not in sys.path:
+        sys.path.insert(0, str(PACKAGE_ROOT))
+
+    from talks_reducer.cli import gather_input_files
+    from talks_reducer.ffmpeg import FFmpegNotFoundError
+    from talks_reducer.models import ProcessingOptions
+    from talks_reducer.pipeline import speed_up_video
+    from talks_reducer.progress import ProgressHandle, SignalProgressReporter
 
 try:
     from tkinterdnd2 import DND_FILES, TkinterDnD


### PR DESCRIPTION
## Summary
- allow the GUI module to fall back to absolute imports when executed without a package context so the PyInstaller binary launches correctly on Windows
- keep the Windows PyInstaller artifact named talks-reducer-gui.exe while preserving the macOS rename step
- update the README to document the new artifact names

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68e2a4dc5500832cb846ab57c137cb76