### PR TITLE
Allow talks-reducer-gui entry point to fall back to CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,10 @@ pip install talks-reducer
 The `--small` preset applies a 720p video scale and 128 kbps audio bitrate, making it useful for sharing talks over constrained
 connections. Without `--small`, the script aims to preserve original quality while removing silence.
 
+> **Tip:** Running `talks-reducer-gui` without arguments opens the Tkinter interface. Passing regular CLI options (for example,
+> `talks-reducer-gui --small input.mp4`) now executes the command-line pipeline, so you can keep a single shortcut for both
+> workflows.
+
 When CUDA-capable hardware is available the pipeline leans on GPU encoders to keep export times low, but it still runs great on
 CPUs.
 

--- a/talks_reducer/cli.py
+++ b/talks_reducer/cli.py
@@ -7,7 +7,7 @@ import os
 import sys
 import time
 from pathlib import Path
-from typing import Dict, List
+from typing import Dict, List, Optional, Sequence
 
 from . import audio
 from .ffmpeg import FFmpegNotFoundError
@@ -99,11 +99,11 @@ def gather_input_files(paths: List[str]) -> List[str]:
     return files
 
 
-def main() -> None:
+def main(argv: Optional[Sequence[str]] = None) -> None:
     """Entry point for the command line interface."""
 
     parser = _build_parser()
-    parsed_args = parser.parse_args()
+    parsed_args = parser.parse_args(argv)
     start_time = time.time()
 
     files = gather_input_files(parsed_args.input_file)

--- a/talks_reducer/gui.py
+++ b/talks_reducer/gui.py
@@ -9,10 +9,11 @@ import threading
 import tkinter as tk
 from pathlib import Path
 from tkinter import filedialog, messagebox, ttk
-from typing import Callable, Iterable, List, Optional
+from typing import Callable, Iterable, List, Optional, Sequence
 
 try:
     from .cli import gather_input_files
+    from .cli import main as cli_main
     from .ffmpeg import FFmpegNotFoundError
     from .models import ProcessingOptions
     from .pipeline import speed_up_video
@@ -26,6 +27,7 @@ except ImportError:  # pragma: no cover - handled at runtime
         sys.path.insert(0, str(PACKAGE_ROOT))
 
     from talks_reducer.cli import gather_input_files
+    from talks_reducer.cli import main as cli_main
     from talks_reducer.ffmpeg import FFmpegNotFoundError
     from talks_reducer.models import ProcessingOptions
     from talks_reducer.pipeline import speed_up_video
@@ -839,8 +841,15 @@ class TalksReducerGUI:
         self.root.mainloop()
 
 
-def main() -> None:
-    """Entry-point used by the ``talks-reducer-gui`` console script."""
+def main(argv: Optional[Sequence[str]] = None) -> None:
+    """Launch the GUI when run without arguments, otherwise defer to the CLI."""
+
+    if argv is None:
+        argv = sys.argv[1:]
+
+    if argv:
+        cli_main(argv)
+        return
 
     app = TalksReducerGUI()
     app.run()


### PR DESCRIPTION
## Summary
- allow the CLI entry point to accept an argument list so it can be reused by other entry points
- update the GUI launcher to open the window when run without arguments and reuse the CLI when options are provided
- document the dual GUI/CLI behavior in the README for binary users

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68e2a97dee24832caa6e50192131f2a0