### PR TITLE
Fix ffprobe validation for Windows ffmpeg builds

### DIFF
--- a/tests/test_audio.py
+++ b/tests/test_audio.py
@@ -1,0 +1,47 @@
+"""Tests for the audio helper utilities."""
+
+from __future__ import annotations
+
+import types
+
+from talks_reducer import audio
+
+
+def _make_completed_process(stdout: str = "", stderr: str = "", returncode: int = 0):
+    """Create a minimal object emulating :class:`subprocess.CompletedProcess`."""
+
+    completed = types.SimpleNamespace()
+    completed.stdout = stdout
+    completed.stderr = stderr
+    completed.returncode = returncode
+    return completed
+
+
+def test_is_valid_input_file_accepts_warnings(monkeypatch):
+    """A warning written to stderr should not invalidate a valid audio file."""
+
+    monkeypatch.setattr(audio, "get_ffprobe_path", lambda: "ffprobe")
+
+    def fake_run(*args, **kwargs):
+        return _make_completed_process(
+            stdout="[STREAM]\ncodec_type=audio\n[/STREAM]\n",
+            stderr="Configuration warning",
+            returncode=0,
+        )
+
+    monkeypatch.setattr(audio.subprocess, "run", fake_run)
+
+    assert audio.is_valid_input_file("example.mp4") is True
+
+
+def test_is_valid_input_file_requires_audio_stream(monkeypatch):
+    """Return ``False`` when ffprobe completes but finds no audio stream."""
+
+    monkeypatch.setattr(audio, "get_ffprobe_path", lambda: "ffprobe")
+
+    def fake_run(*args, **kwargs):
+        return _make_completed_process(stdout="", stderr="", returncode=0)
+
+    monkeypatch.setattr(audio.subprocess, "run", fake_run)
+
+    assert audio.is_valid_input_file("silent.mp4") is False


### PR DESCRIPTION
## Summary
- update the ffprobe based input validation to treat stderr warnings as non-fatal and rely on the return code
- extend the timeout and simplify stdout parsing to reliably detect audio streams across platforms
- add unit tests covering the new validation logic for files with warnings and without audio

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68e41295a220832c8d19f1915a739c41