### PR TITLE
Launch GUI from CLI when invoked without arguments

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,11 +26,13 @@ pip install talks-reducer
 
 **Note:** FFmpeg is now bundled automatically with the package, so you don't need to install it separately. However, if you have FFmpeg already installed on your system, it will be used instead of the bundled version.
 
+Running the `talks-reducer` command with no arguments now launches the GUI, making the console entry point universal across Windows, macOS, and Linux. Supply a video path or the `--help` flag to stay in CLI mode.
+
 The `--small` preset applies a 720p video scale and 128 kbps audio bitrate, making it useful for sharing talks over constrained
 connections. Without `--small`, the script aims to preserve original quality while removing silence.
 
-> **Tip:** Running `talks-reducer-gui` without arguments opens the Tkinter interface. Passing regular CLI options (for example,
-> `talks-reducer-gui --small input.mp4`) now executes the command-line pipeline, so you can keep a single shortcut for both
+> **Tip:** Running `talks-reducer` or `talks-reducer-gui` without arguments opens the Tkinter interface. Passing regular CLI options (for example,
+> `talks-reducer --small input.mp4`) now executes the command-line pipeline, so you can keep a single shortcut for both
 > workflows.
 
 When CUDA-capable hardware is available the pipeline leans on GPU encoders to keep export times low, but it still runs great on

--- a/talks_reducer/cli.py
+++ b/talks_reducer/cli.py
@@ -23,19 +23,19 @@ def _build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(
         description="Modifies a video file to play at different speeds when there is sound vs. silence.",
     )
-    
+
     # Add version argument
     try:
         pkg_version = version("talks-reducer")
     except Exception:
         pkg_version = "unknown"
-    
+
     parser.add_argument(
         "--version",
         action="version",
         version=f"talks-reducer {pkg_version}",
     )
-    
+
     parser.add_argument(
         "input_file",
         type=str,
@@ -113,31 +113,30 @@ def gather_input_files(paths: List[str]) -> List[str]:
     return files
 
 
+def _attempt_gui_launch(argv: Sequence[str]) -> bool:
+    """Try to start the GUI, returning ``True`` when it launches successfully."""
+
+    try:
+        from .gui import main as gui_main
+    except ImportError:
+        return False
+
+    try:
+        return bool(gui_main(list(argv)))
+    except Exception:
+        return False
+
+
 def main(argv: Optional[Sequence[str]] = None) -> None:
     """Entry point for the command line interface.
 
     Launch the GUI when run without arguments, otherwise defer to the CLI.
     """
 
-    # Check if running without arguments
-    if argv is None:
-        argv_list = sys.argv[1:]
-    else:
-        argv_list = list(argv)
+    argv_list = list(sys.argv[1:] if argv is None else argv)
 
-    # Launch GUI if no arguments provided
     if not argv_list:
-        gui_launched = False
-
-        try:
-            from .gui import main as gui_main
-
-            gui_launched = gui_main([])
-        except ImportError:
-            # GUI dependencies not available, show help instead
-            gui_launched = False
-
-        if gui_launched:
+        if _attempt_gui_launch(argv_list):
             return
 
         parser = _build_parser()
@@ -145,7 +144,7 @@ def main(argv: Optional[Sequence[str]] = None) -> None:
         return
 
     parser = _build_parser()
-    parsed_args = parser.parse_args(argv)
+    parsed_args = parser.parse_args(argv_list)
     start_time = time.time()
 
     files = gather_input_files(parsed_args.input_file)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,133 @@
+"""Tests for the command line interface entry point."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from types import SimpleNamespace
+from typing import List
+
+import pytest
+
+from talks_reducer import cli
+
+
+class _DummyParser:
+    """Small helper parser used to assert CLI flow without argparse."""
+
+    def __init__(self) -> None:
+        self.help_called = False
+        self.parsed_args: List[str] | None = None
+
+    def print_help(self) -> None:
+        self.help_called = True
+
+    def parse_args(self, args: List[str]):  # pragma: no cover - not used in help test
+        self.parsed_args = list(args)
+        return SimpleNamespace(
+            input_file=args,
+            output_file=None,
+            temp_folder=None,
+            silent_threshold=None,
+            silent_speed=None,
+            sounded_speed=None,
+            frame_spreadage=None,
+            sample_rate=None,
+            small=False,
+        )
+
+
+def test_main_launches_gui_when_no_arguments(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Ensure the GUI branch is exercised when no CLI args are provided."""
+
+    captured: dict[str, List[str]] = {}
+
+    def fake_launch(argv: List[str]) -> bool:
+        captured["argv"] = list(argv)
+        return True
+
+    monkeypatch.setattr(cli, "_attempt_gui_launch", fake_launch)
+
+    build_called = False
+
+    def fake_build_parser() -> _DummyParser:
+        nonlocal build_called
+        build_called = True
+        return _DummyParser()
+
+    monkeypatch.setattr(cli, "_build_parser", fake_build_parser)
+
+    cli.main([])
+
+    assert captured["argv"] == []
+    assert build_called is False
+
+
+def test_main_prints_help_when_gui_unavailable(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Verify the CLI gracefully falls back to help output when GUI fails."""
+
+    monkeypatch.setattr(cli, "_attempt_gui_launch", lambda argv: False)
+
+    parser = _DummyParser()
+    monkeypatch.setattr(cli, "_build_parser", lambda: parser)
+
+    cli.main([])
+
+    assert parser.help_called is True
+
+
+def test_main_processes_cli_arguments(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Confirm the standard CLI execution path still runs the pipeline."""
+
+    parsed: dict[str, object] = {}
+
+    def fake_build_parser() -> _DummyParser:
+        class Parser(_DummyParser):
+            def parse_args(self, args: List[str]):
+                parsed["parse_args"] = list(args)
+                return SimpleNamespace(
+                    input_file=args,
+                    output_file="output.mp4",
+                    temp_folder="TEMP",
+                    silent_threshold=0.05,
+                    silent_speed=3.0,
+                    sounded_speed=1.0,
+                    frame_spreadage=3,
+                    sample_rate=48000,
+                    small=True,
+                )
+
+        return Parser()
+
+    monkeypatch.setattr(cli, "_build_parser", fake_build_parser)
+    monkeypatch.setattr(cli, "gather_input_files", lambda paths: paths)
+
+    class DummyReporter:
+        def log(self, message: str) -> None:  # pragma: no cover - simple stub
+            parsed.setdefault("logs", []).append(message)
+
+    monkeypatch.setattr(cli, "TqdmProgressReporter", lambda: DummyReporter())
+
+    class DummyResult:
+        def __init__(self, output_file: str) -> None:
+            self.output_file = Path(output_file)
+
+    def fake_speed(options, reporter) -> DummyResult:
+        parsed["options"] = options
+        return DummyResult("final.mp4")
+
+    monkeypatch.setattr(cli, "speed_up_video", fake_speed)
+    monkeypatch.setattr(cli, "ProcessingOptions", lambda **kwargs: kwargs)
+
+    cli.main(["input.mp4"])
+
+    assert parsed["parse_args"] == ["input.mp4"]
+    assert parsed["options"]["input_file"] == Path("input.mp4")
+    assert parsed["options"]["output_file"] == Path("output.mp4")
+    assert parsed["options"]["temp_folder"] == Path("TEMP")
+    assert parsed["options"]["silent_threshold"] == 0.05
+    assert parsed["options"]["silent_speed"] == 3.0
+    assert parsed["options"]["sounded_speed"] == 1.0
+    assert parsed["options"]["frame_spreadage"] == 3
+    assert parsed["options"]["sample_rate"] == 48000
+    assert parsed["options"]["small"] is True
+    assert parsed["logs"] == ["Completed: final.mp4"]


### PR DESCRIPTION
## Summary
- ensure the CLI entry point launches the GUI when run with no arguments and falls back to help output if the GUI is unavailable
- document the universal `talks-reducer` command behaviour across platforms
- add tests that cover the GUI launch, help fallback, and CLI execution paths

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68e419ca2138832c8f7db414c5e488d0