### PR TITLE
feat: launch gui when cli has no arguments

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,9 +29,9 @@ pip install talks-reducer
 The `--small` preset applies a 720p video scale and 128 kbps audio bitrate, making it useful for sharing talks over constrained
 connections. Without `--small`, the script aims to preserve original quality while removing silence.
 
-> **Tip:** Running `talks-reducer-gui` without arguments opens the Tkinter interface. Passing regular CLI options (for example,
-> `talks-reducer-gui --small input.mp4`) now executes the command-line pipeline, so you can keep a single shortcut for both
-> workflows.
+> **Tip:** The `talks-reducer` and `talks-reducer-gui` commands now behave the same way: launching them without arguments opens
+> the Tkinter interface, while passing regular CLI options (for example, `talks-reducer --small input.mp4`) executes the
+> command-line pipeline. You can keep a single shortcut for both workflows.
 
 When CUDA-capable hardware is available the pipeline leans on GPU encoders to keep export times low, but it still runs great on
 CPUs.

--- a/launcher.py
+++ b/launcher.py
@@ -1,8 +1,8 @@
 #!/usr/bin/env python
 """Launcher script for PyInstaller builds."""
 
-import sys
 import io
+import sys
 
 # On Windows, if built with --windowed, stdout/stderr might be None
 # Ensure they always have a valid file-like object to prevent attribute errors
@@ -19,23 +19,23 @@ if sys.platform == "win32":
 if sys.platform == "win32" and len(sys.argv) > 1:
     try:
         import ctypes
-        
+
         kernel32 = ctypes.windll.kernel32
-        
+
         # Try to attach to parent console (only works when launched from cmd/terminal)
         # AttachConsole returns 0 on failure
         if kernel32.AttachConsole(ctypes.c_ulong(-1)):  # ATTACH_PARENT_PROCESS = -1
             # Reopen stdout and stderr to the console
             try:
-                if hasattr(sys.stdout, 'close'):
+                if hasattr(sys.stdout, "close"):
                     sys.stdout.close()
-                if hasattr(sys.stderr, 'close'):
+                if hasattr(sys.stderr, "close"):
                     sys.stderr.close()
-                if hasattr(sys.stdin, 'close'):
+                if hasattr(sys.stdin, "close"):
                     sys.stdin.close()
             except Exception:
                 pass
-            
+
             try:
                 sys.stdout = open("CONOUT$", "w", encoding="utf-8")
                 sys.stderr = open("CONOUT$", "w", encoding="utf-8")

--- a/talks_reducer/ffmpeg.py
+++ b/talks_reducer/ffmpeg.py
@@ -38,6 +38,7 @@ def find_ffmpeg() -> Optional[str]:
     # Try bundled ffmpeg from imageio-ffmpeg first
     try:
         import imageio_ffmpeg
+
         bundled_path = imageio_ffmpeg.get_ffmpeg_exe()
         if bundled_path and os.path.isfile(bundled_path):
             return bundled_path
@@ -161,11 +162,11 @@ def check_cuda_available(ffmpeg_path: Optional[str] = None) -> bool:
     try:
         ffmpeg_path = ffmpeg_path or get_ffmpeg_path()
         result = subprocess.run(
-            [ffmpeg_path, "-encoders"], 
-            capture_output=True, 
-            text=True, 
+            [ffmpeg_path, "-encoders"],
+            capture_output=True,
+            text=True,
             timeout=5,
-            creationflags=creationflags
+            creationflags=creationflags,
         )
     except (
         subprocess.TimeoutExpired,
@@ -193,7 +194,7 @@ def run_timed_ffmpeg_command(
     process_callback: Optional[callable] = None,
 ) -> None:
     """Execute an FFmpeg command while streaming progress information.
-    
+
     Args:
         process_callback: Optional callback that receives the subprocess.Popen object
     """
@@ -243,7 +244,7 @@ def run_timed_ffmpeg_command(
 
             sys.stderr.write(line)
             sys.stderr.flush()
-            
+
             # Send FFmpeg output to reporter for GUI display
             progress_reporter.log(line.strip())
 

--- a/talks_reducer/pipeline.py
+++ b/talks_reducer/pipeline.py
@@ -158,7 +158,7 @@ def speed_up_video(
     )
 
     reporter.log("Extracting audio...")
-    process_callback = getattr(reporter, 'process_callback', None)
+    process_callback = getattr(reporter, "process_callback", None)
     run_timed_ffmpeg_command(
         extract_command,
         reporter=reporter,

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,78 @@
+"""Tests for the CLI entry point behaviour."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from types import SimpleNamespace
+from unittest import mock
+
+import pytest
+
+from talks_reducer import cli
+
+
+def test_main_launches_gui_when_no_args(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The GUI should be launched when no CLI arguments are provided."""
+
+    launch_calls: list[list[str]] = []
+
+    def fake_launch(argv: list[str]) -> bool:
+        launch_calls.append(list(argv))
+        return True
+
+    def fail_build_parser() -> None:
+        raise AssertionError("Parser should not be built when GUI launches")
+
+    monkeypatch.setattr(cli, "_launch_gui", fake_launch)
+    monkeypatch.setattr(cli, "_build_parser", fail_build_parser)
+
+    cli.main([])
+
+    assert launch_calls == [[]]
+
+
+def test_main_runs_cli_with_arguments(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Providing CLI arguments should bypass the GUI and run the pipeline."""
+
+    parsed_args = SimpleNamespace(
+        input_file=["input.mp4"],
+        output_file=None,
+        temp_folder=None,
+        silent_threshold=None,
+        silent_speed=None,
+        sounded_speed=None,
+        frame_spreadage=None,
+        sample_rate=None,
+        small=False,
+    )
+
+    parser_mock = mock.Mock()
+    parser_mock.parse_args.return_value = parsed_args
+
+    outputs: list[cli.ProcessingOptions] = []
+
+    class DummyReporter:
+        def log(self, _message: str) -> None:  # pragma: no cover - simple stub
+            pass
+
+    def fake_speed_up_video(options: cli.ProcessingOptions, reporter: object):
+        outputs.append(options)
+        return SimpleNamespace(output_file=Path("/tmp/output.mp4"))
+
+    def fake_gather_input_files(_paths: list[str]) -> list[str]:
+        return ["/tmp/input.mp4"]
+
+    def fail_launch(_argv: list[str]) -> bool:
+        raise AssertionError("GUI should not be launched when arguments exist")
+
+    monkeypatch.setattr(cli, "_build_parser", lambda: parser_mock)
+    monkeypatch.setattr(cli, "gather_input_files", fake_gather_input_files)
+    monkeypatch.setattr(cli, "speed_up_video", fake_speed_up_video)
+    monkeypatch.setattr(cli, "TqdmProgressReporter", lambda: DummyReporter())
+    monkeypatch.setattr(cli, "_launch_gui", fail_launch)
+
+    cli.main(["input.mp4"])
+
+    parser_mock.parse_args.assert_called_once_with(["input.mp4"])
+    assert len(outputs) == 1
+    assert outputs[0].input_file == Path("/tmp/input.mp4")


### PR DESCRIPTION
## Summary
- ensure the CLI entry point launches the Tk GUI when no arguments are provided and fall back to CLI help otherwise
- add regression tests covering GUI dispatch and CLI execution paths
- document the universal entry-point behaviour in the README

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68e419ca2138832c8f7db414c5e488d0