### PR TITLE
Add CLI helper for Talks Reducer server automation

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,30 @@ This opens a local web page featuring a drag-and-drop upload zone, a **Small vid
 progress indicator, and automatic previews of the processed output. Once the job completes you can inspect the resulting compression
 ratio and download the rendered video directly from the page.
 
+### Uploading and retrieving a processed video
+
+1. Open the printed `http://localhost:<port>` address (the default port is `9005`).
+2. Drag a video onto the **Video file** drop zone or click to browse and select one from disk.
+3. (Optional) Enable **Small video** before the upload finishes to apply the 720p/128 kbps preset.
+4. Wait for the progress bar and log to report completion—the interface queues work automatically after the file arrives.
+5. Watch the processed preview in the **Processed video** player and click **Download processed file** to save the result locally.
+
+Need to change where the server listens? Run `talks-reducer server --host 0.0.0.0 --port 7860` (or any other port) to bind to a
+different address.
+
+### Automating uploads from the command line
+
+Prefer to script uploads instead of using the browser UI? Start the server and use the bundled helper to submit a job and save
+the processed video locally:
+
+```sh
+python -m talks_reducer.service_client --server http://127.0.0.1:9005/ --input demo.mp4 --output output/demo_processed.mp4
+```
+
+The helper wraps the Gradio API exposed by `server.py`, waits for processing to complete, then copies the rendered file to the
+path you provide. Pass `--small` to mirror the **Small video** checkbox or `--print-log` to stream the server log after the
+download finishes.
+
 ## Contributing
 See `CONTRIBUTION.md` for development setup details and guidance on sharing improvements.
 

--- a/talks_reducer/server.py
+++ b/talks_reducer/server.py
@@ -296,6 +296,7 @@ def build_interface() -> gr.Blocks:
             inputs=[file_input, small_checkbox],
             outputs=[video_output, log_output, summary_output, download_output],
             queue=True,
+            api_name="process_video",
         )
 
     demo.queue(default_concurrency_limit=1)

--- a/talks_reducer/service_client.py
+++ b/talks_reducer/service_client.py
@@ -1,0 +1,101 @@
+"""Command-line helper for sending videos to the Talks Reducer server."""
+
+from __future__ import annotations
+
+import argparse
+import shutil
+from pathlib import Path
+from typing import Optional, Sequence, Tuple
+
+from gradio_client import Client, file as gradio_file
+
+
+def send_video(
+    input_path: Path,
+    output_path: Optional[Path],
+    server_url: str,
+    small: bool = False,
+) -> Tuple[Path, str, str]:
+    """Upload *input_path* to the Gradio server and download the processed video."""
+
+    if not input_path.exists():
+        raise FileNotFoundError(f"Input file does not exist: {input_path}")
+
+    client = Client(server_url)
+    prediction = client.predict(
+        gradio_file(str(input_path)),
+        bool(small),
+        api_name="/process_video",
+    )
+
+    try:
+        _, log_text, summary, download_path = prediction
+    except (TypeError, ValueError) as exc:  # pragma: no cover - defensive
+        raise RuntimeError("Unexpected response from server") from exc
+
+    if not download_path:
+        raise RuntimeError("Server did not return a processed file")
+
+    download_source = Path(str(download_path))
+    if output_path is None:
+        destination = Path.cwd() / download_source.name
+    else:
+        destination = output_path
+        if destination.is_dir():
+            destination = destination / download_source.name
+
+    destination.parent.mkdir(parents=True, exist_ok=True)
+    if download_source.resolve() != destination.resolve():
+        shutil.copy2(download_source, destination)
+
+    return destination, summary, log_text
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Send a video to a running talks-reducer server and download the result.",
+    )
+    parser.add_argument("input", type=Path, help="Path to the video file to upload.")
+    parser.add_argument(
+        "--server",
+        default="http://127.0.0.1:9005/",
+        help="Base URL for the talks-reducer server (default: http://127.0.0.1:9005/).",
+    )
+    parser.add_argument(
+        "--output",
+        type=Path,
+        default=None,
+        help="Where to store the processed video. Defaults to the working directory.",
+    )
+    parser.add_argument(
+        "--small",
+        action="store_true",
+        help="Toggle the 'Small video' preset before processing.",
+    )
+    parser.add_argument(
+        "--print-log",
+        action="store_true",
+        help="Print the server log after processing completes.",
+    )
+    return parser
+
+
+def main(argv: Optional[Sequence[str]] = None) -> None:
+    parser = _build_parser()
+    args = parser.parse_args(argv)
+
+    destination, summary, log_text = send_video(
+        input_path=args.input.expanduser(),
+        output_path=args.output.expanduser() if args.output else None,
+        server_url=args.server,
+        small=args.small,
+    )
+
+    print(summary)
+    print(f"Saved processed video to {destination}")
+    if args.print_log:
+        print("\nServer log:\n" + log_text)
+
+
+if __name__ == "__main__":  # pragma: no cover
+    main()

--- a/tests/test_service_client.py
+++ b/tests/test_service_client.py
@@ -1,0 +1,112 @@
+from types import SimpleNamespace
+
+import pytest
+
+from talks_reducer import service_client
+
+
+class DummyClient:
+    def __init__(self, server_url: str) -> None:
+        self.server_url = server_url
+        self.predictions = []
+
+    def predict(self, *args, **kwargs):  # pragma: no cover - replaced in tests
+        raise NotImplementedError
+
+
+def test_send_video_downloads_file(monkeypatch, tmp_path):
+    input_file = tmp_path / "input.mp4"
+    input_file.write_bytes(b"input")
+    server_file = tmp_path / "server_output.mp4"
+    server_file.write_bytes(b"processed")
+
+    client_instance = DummyClient("http://localhost:9005/")
+
+    def fake_predict(file_arg, small_flag, api_name):
+        assert api_name == "/process_video"
+        assert small_flag is True
+        client_instance.predictions.append((file_arg, small_flag, api_name))
+        return (None, "log", "summary", str(server_file))
+
+    client_instance.predict = fake_predict
+
+    monkeypatch.setattr(service_client, "Client", lambda url: client_instance)
+    monkeypatch.setattr(
+        service_client, "gradio_file", lambda path: SimpleNamespace(path=path)
+    )
+
+    destination, summary, log_text = service_client.send_video(
+        input_path=input_file,
+        output_path=tmp_path / "output.mp4",
+        server_url="http://localhost:9005/",
+        small=True,
+    )
+
+    assert destination == tmp_path / "output.mp4"
+    assert destination.read_bytes() == server_file.read_bytes()
+    assert summary == "summary"
+    assert log_text == "log"
+    assert client_instance.predictions, "predict was not called"
+
+
+def test_send_video_defaults_to_current_directory(monkeypatch, tmp_path, cwd_tmp_path):
+    input_file = tmp_path / "input.mp4"
+    input_file.write_bytes(b"input")
+    server_file = tmp_path / "server_output.mp4"
+    server_file.write_bytes(b"processed")
+
+    client_instance = DummyClient("http://localhost:9005/")
+    client_instance.predict = lambda *_, **__: (
+        None,
+        "log",
+        "summary",
+        str(server_file),
+    )
+
+    monkeypatch.setattr(service_client, "Client", lambda url: client_instance)
+    monkeypatch.setattr(
+        service_client, "gradio_file", lambda path: SimpleNamespace(path=path)
+    )
+
+    destination, _, _ = service_client.send_video(
+        input_path=input_file,
+        output_path=None,
+        server_url="http://localhost:9005/",
+    )
+
+    assert destination.parent == cwd_tmp_path
+    assert destination.name == server_file.name
+    assert destination.read_bytes() == server_file.read_bytes()
+
+
+def test_main_prints_summary(monkeypatch, tmp_path, capsys):
+    input_file = tmp_path / "input.mp4"
+    destination_file = tmp_path / "output.mp4"
+
+    def fake_send_video(**kwargs):
+        assert kwargs["small"] is False
+        return destination_file, "summary", "log"
+
+    monkeypatch.setattr(
+        service_client, "send_video", lambda **kwargs: fake_send_video(**kwargs)
+    )
+
+    service_client.main(
+        [
+            str(input_file),
+            "--server",
+            "http://localhost:9005/",
+            "--output",
+            str(destination_file),
+        ]
+    )
+
+    captured = capsys.readouterr()
+    assert "summary" in captured.out
+    assert str(destination_file) in captured.out
+
+
+@pytest.fixture
+def cwd_tmp_path(monkeypatch, tmp_path):
+    monkeypatch.chdir(tmp_path)
+    return tmp_path


### PR DESCRIPTION
## Summary
- add a command-line helper that submits videos to the running Gradio server and saves the processed output
- document scripted usage and expose a stable API name on the server upload event
- add unit tests for the helper logic and CLI entry point

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68e55bd0c0b0832c8a44f776ae60144e