### PR TITLE
Add system tray launcher for web server

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -34,7 +34,11 @@
             "request": "launch",
             "module": "talks_reducer.server_tray",
             "args": [
-                "--host", "0.0.0.0"
+                "--host",
+                "0.0.0.0",
+                "--tray-mode",
+                "pystray-detached",
+                "--debug"
             ],
             "console": "integratedTerminal",
             "cwd": "${workspaceFolder}"

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -29,6 +29,17 @@
             "cwd": "${workspaceFolder}"
         },
         {
+            "name": "server-tray",
+            "type": "debugpy",
+            "request": "launch",
+            "module": "talks_reducer.server_tray",
+            "args": [
+                "--host", "0.0.0.0"
+            ],
+            "console": "integratedTerminal",
+            "cwd": "${workspaceFolder}"
+        },
+        {
             "name": "docs/assets/demo.mp4",
             "type": "debugpy",
             "request": "launch",

--- a/README.md
+++ b/README.md
@@ -70,7 +70,9 @@ the web server running without a tray process. The tray menu includes an **Open 
 item (also triggered by double-clicking the icon) that launches the desktop
 Talks Reducer interface alongside an **Open WebUI** entry that opens the Gradio
 page in your browser. Close the GUI window to return to the tray without
-stopping the server. The tray no longer opens a browser automatically—pass
+stopping the server. The GUI now launches automatically when the tray starts;
+pass `--no-gui` if you prefer to spawn it manually, or `--open-gui` to override
+other presets. The tray no longer opens a browser automatically—pass
 `--open-browser` if you prefer the web page to launch as soon as the server is
 ready.
 

--- a/README.md
+++ b/README.md
@@ -57,6 +57,12 @@ Prefer a lightweight browser interface? Launch the Gradio-powered simple mode wi
 talks-reducer server
 ```
 
+Want the server to live in your system tray instead of a terminal window? Use:
+
+```sh
+talks-reducer server-tray
+```
+
 This opens a local web page featuring a drag-and-drop upload zone, a **Small video** checkbox that mirrors the CLI preset, a live
 progress indicator, and automatic previews of the processed output. Once the job completes you can inspect the resulting compression
 ratio and download the rendered video directly from the page.
@@ -65,7 +71,7 @@ ratio and download the rendered video directly from the page.
 
 1. Open the printed `http://localhost:<port>` address (the default port is `9005`).
 2. Drag a video onto the **Video file** drop zone or click to browse and select one from disk.
-3. (Optional) Enable **Small video** before the upload finishes to apply the 720p/128 kbps preset.
+3. **Small video** starts enabled to apply the 720p/128 kbps preset. Clear the box before the upload finishes if you want to keep the original resolution and bitrate.
 4. Wait for the progress bar and log to report completion—the interface queues work automatically after the file arrives.
 5. Watch the processed preview in the **Processed video** player and click **Download processed file** to save the result locally.
 

--- a/README.md
+++ b/README.md
@@ -70,11 +70,14 @@ the web server running without a tray process. The tray menu includes an **Open 
 item (also triggered by double-clicking the icon) that launches the desktop
 Talks Reducer interface alongside an **Open WebUI** entry that opens the Gradio
 page in your browser. Close the GUI window to return to the tray without
-stopping the server. The GUI now launches automatically when the tray starts;
-pass `--no-gui` if you prefer to spawn it manually, or `--open-gui` to override
-other presets. The tray no longer opens a browser automatically—pass
-`--open-browser` if you prefer the web page to launch as soon as the server is
-ready.
+stopping the server. Launching the GUI directly now starts the tray-backed
+server in the background before the window appears so the icon stays available
+after you close it; add `--no-tray` when running `python -m talks_reducer.gui`
+if you prefer to skip the background server entirely. The tray command itself
+never launches the GUI automatically, so use the menu item (or rerun the GUI
+with `--no-tray`) whenever you want to reopen it. The tray no longer opens a
+browser automatically—pass `--open-browser` if you prefer the web page to
+launch as soon as the server is ready.
 
 This opens a local web page featuring a drag-and-drop upload zone, a **Small video** checkbox that mirrors the CLI preset, a live
 progress indicator, and automatic previews of the processed output. Once the job completes you can inspect the resulting compression

--- a/README.md
+++ b/README.md
@@ -66,7 +66,13 @@ talks-reducer server-tray
 Pass `--debug` to print verbose logs about the tray icon lifecycle, and
 `--tray-mode pystray-detached` to try pystray's alternate detached runner. If
 the icon backend refuses to appear, fall back to `--tray-mode headless` to keep
-the web server running without a tray process.
+the web server running without a tray process. The tray menu includes an **Open GUI**
+item (also triggered by double-clicking the icon) that launches the desktop
+Talks Reducer interface alongside an **Open WebUI** entry that opens the Gradio
+page in your browser. Close the GUI window to return to the tray without
+stopping the server. The tray no longer opens a browser automatically—pass
+`--open-browser` if you prefer the web page to launch as soon as the server is
+ready.
 
 This opens a local web page featuring a drag-and-drop upload zone, a **Small video** checkbox that mirrors the CLI preset, a live
 progress indicator, and automatic previews of the processed output. Once the job completes you can inspect the resulting compression

--- a/README.md
+++ b/README.md
@@ -63,6 +63,11 @@ Want the server to live in your system tray instead of a terminal window? Use:
 talks-reducer server-tray
 ```
 
+Pass `--debug` to print verbose logs about the tray icon lifecycle, and
+`--tray-mode pystray-detached` to try pystray's alternate detached runner. If
+the icon backend refuses to appear, fall back to `--tray-mode headless` to keep
+the web server running without a tray process.
+
 This opens a local web page featuring a drag-and-drop upload zone, a **Small video** checkbox that mirrors the CLI preset, a live
 progress indicator, and automatic previews of the processed output. Once the job completes you can inspect the resulting compression
 ratio and download the rendered video directly from the page.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,6 +19,7 @@ dependencies = [
     "tqdm>=4.65.0",
     "tkinterdnd2>=0.3.0",
     "Pillow>=9.0.0",
+    "pystray>=0.19.5",
     "imageio-ffmpeg>=0.4.8",
     "gradio>=4.0.0",
 ]
@@ -38,6 +39,7 @@ dev = [
 talks-reducer = "talks_reducer.cli:main"
 talks-reducer-gui = "talks_reducer.gui:main"
 talks-reducer-server = "talks_reducer.server:main"
+talks-reducer-server-tray = "talks_reducer.server_tray:main"
 
 [tool.setuptools.dynamic]
 version = {attr = "talks_reducer.__about__.__version__"}

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,5 +4,6 @@ numpy>=1.22.0
 tqdm>=4.65.0
 tkinterdnd2>=0.3.0
 Pillow>=9.0.0
+pystray>=0.19.5
 imageio-ffmpeg>=0.4.8
 gradio>=4.0.0

--- a/talks_reducer/server.py
+++ b/talks_reducer/server.py
@@ -273,8 +273,9 @@ def build_interface() -> gr.Blocks:
         gr.Markdown(
             """
             ## Talks Reducer — Simple Server
-            Drop a video into the zone below or click to browse. Toggle **Small video** to
-            apply the 720p/128k preset before processing starts.
+            Drop a video into the zone below or click to browse. **Small video** is enabled
+            by default to apply the 720p/128k preset before processing starts—clear it to
+            keep the original resolution.
             """.strip()
         )
 
@@ -284,7 +285,7 @@ def build_interface() -> gr.Blocks:
                 file_types=["video"],
                 type="filepath",
             )
-            small_checkbox = gr.Checkbox(label="Small video", value=False)
+            small_checkbox = gr.Checkbox(label="Small video", value=True)
 
         video_output = gr.Video(label="Processed video")
         summary_output = gr.Markdown()

--- a/talks_reducer/server_tray.py
+++ b/talks_reducer/server_tray.py
@@ -91,14 +91,12 @@ class _ServerTrayApplication:
         share: bool,
         open_browser: bool,
         tray_mode: str,
-        open_gui: bool,
     ) -> None:
         self._host = host
         self._port = port
         self._share = share
         self._open_browser_on_start = open_browser
         self._tray_mode = tray_mode
-        self._open_gui_on_start = open_gui
 
         self._stop_event = threading.Event()
         self._ready_event = threading.Event()
@@ -206,7 +204,9 @@ class _ServerTrayApplication:
 
             try:
                 LOGGER.info("Launching Talks Reducer GUI via %s", sys.executable)
-                process = subprocess.Popen([sys.executable, "-m", "talks_reducer.gui"])
+                process = subprocess.Popen(
+                    [sys.executable, "-m", "talks_reducer.gui", "--no-tray"]
+                )
             except Exception as exc:  # pragma: no cover - platform specific
                 LOGGER.error("Failed to launch Talks Reducer GUI: %s", exc)
                 self._gui_process = None
@@ -248,9 +248,6 @@ class _ServerTrayApplication:
 
         if self._open_browser_on_start:
             self._handle_open_webui()
-
-        if self._open_gui_on_start:
-            self._launch_gui()
 
         if self._tray_mode == "headless":
             LOGGER.warning(
@@ -377,20 +374,6 @@ def main(argv: Optional[Sequence[str]] = None) -> None:
             "pystray worker, or disable the tray entirely."
         ),
     )
-    gui_group = parser.add_mutually_exclusive_group()
-    gui_group.add_argument(
-        "--open-gui",
-        dest="open_gui",
-        action="store_true",
-        help="Launch the Talks Reducer desktop GUI after startup (default).",
-    )
-    gui_group.add_argument(
-        "--no-gui",
-        dest="open_gui",
-        action="store_false",
-        help="Skip launching the desktop GUI automatically.",
-    )
-    parser.set_defaults(open_gui=True)
     parser.add_argument(
         "--debug",
         action="store_true",
@@ -417,7 +400,6 @@ def main(argv: Optional[Sequence[str]] = None) -> None:
         share=args.share,
         open_browser=args.open_browser,
         tray_mode=args.tray_mode,
-        open_gui=args.open_gui,
     )
 
     atexit.register(app.stop)

--- a/talks_reducer/server_tray.py
+++ b/talks_reducer/server_tray.py
@@ -1,0 +1,231 @@
+"""System tray launcher for the Talks Reducer Gradio server."""
+
+from __future__ import annotations
+
+import argparse
+import atexit
+import threading
+import time
+import webbrowser
+from contextlib import suppress
+from pathlib import Path
+from typing import Any, Optional, Sequence
+
+from PIL import Image
+
+from .server import build_interface
+
+try:  # pragma: no cover - import guarded for clearer error message at runtime
+    import pystray
+except ModuleNotFoundError as exc:  # pragma: no cover - handled in ``main``
+    PYSTRAY_IMPORT_ERROR = exc
+    pystray = None  # type: ignore[assignment]
+else:
+    PYSTRAY_IMPORT_ERROR = None
+
+
+def _guess_local_url(host: Optional[str], port: int) -> str:
+    """Return the URL the server is most likely reachable at locally."""
+
+    if host in (None, "", "0.0.0.0", "::"):
+        hostname = "127.0.0.1"
+    else:
+        hostname = host
+    return f"http://{hostname}:{port}/"
+
+
+def _load_icon() -> Image.Image:
+    """Load the tray icon image, falling back to a solid accent square."""
+
+    candidates = [
+        Path(__file__).resolve().parent.parent / "docs" / "assets" / "icon.png",
+        Path(__file__).resolve().parent / "icon.png",
+    ]
+
+    for candidate in candidates:
+        if candidate.exists():
+            with suppress(Exception):
+                return Image.open(candidate).copy()
+
+    # Fallback to a simple accent-colored square to avoid import errors
+    image = Image.new("RGBA", (64, 64), color=(37, 99, 235, 255))
+    return image
+
+
+class _ServerTrayApplication:
+    """Coordinate the Gradio server lifecycle and the system tray icon."""
+
+    def __init__(
+        self,
+        *,
+        host: Optional[str],
+        port: int,
+        share: bool,
+        open_browser: bool,
+    ) -> None:
+        self._host = host
+        self._port = port
+        self._share = share
+        self._open_browser_on_start = open_browser
+
+        self._stop_event = threading.Event()
+        self._ready_event = threading.Event()
+
+        self._server_handle: Optional[Any] = None
+        self._local_url: Optional[str] = None
+        self._share_url: Optional[str] = None
+        self._icon: Optional[pystray.Icon] = None
+
+    # Server lifecycle -------------------------------------------------
+
+    def _launch_server(self) -> None:
+        """Start the Gradio server in the background and record its URLs."""
+
+        demo = build_interface()
+        server = demo.launch(
+            server_name=self._host,
+            server_port=self._port,
+            share=self._share,
+            inbrowser=False,
+            prevent_thread_lock=True,
+            show_error=True,
+        )
+
+        self._server_handle = server
+        self._local_url = getattr(
+            server, "local_url", _guess_local_url(self._host, self._port)
+        )
+        self._share_url = getattr(server, "share_url", None)
+        self._ready_event.set()
+
+        # Keep checking for a share URL while the server is running.
+        while not self._stop_event.is_set():
+            share_url = getattr(server, "share_url", None)
+            if share_url:
+                self._share_url = share_url
+            time.sleep(0.5)
+
+    # Tray helpers -----------------------------------------------------
+
+    def _resolve_url(self) -> Optional[str]:
+        if self._share_url:
+            return self._share_url
+        return self._local_url
+
+    def _handle_open(
+        self,
+        _icon: Optional[pystray.Icon] = None,
+        _item: Optional[pystray.MenuItem] = None,
+    ) -> None:
+        url = self._resolve_url()
+        if url:
+            webbrowser.open(url)
+
+    def _handle_quit(
+        self,
+        icon: Optional[pystray.Icon] = None,
+        _item: Optional[pystray.MenuItem] = None,
+    ) -> None:
+        self.stop()
+        if icon is not None:
+            icon.stop()
+
+    # Public API -------------------------------------------------------
+
+    def run(self) -> None:
+        """Start the server and block until the tray icon exits."""
+
+        server_thread = threading.Thread(
+            target=self._launch_server, name="talks-reducer-server", daemon=True
+        )
+        server_thread.start()
+
+        if not self._ready_event.wait(timeout=30):
+            raise RuntimeError(
+                "Timed out while waiting for the Talks Reducer server to start."
+            )
+
+        if self._open_browser_on_start:
+            self._handle_open()
+
+        icon_image = _load_icon()
+        menu = pystray.Menu(
+            pystray.MenuItem("Open Talks Reducer", self._handle_open),
+            pystray.MenuItem("Quit", self._handle_quit),
+        )
+        self._icon = pystray.Icon(
+            "talks-reducer", icon_image, "Talks Reducer Server", menu=menu
+        )
+        self._icon.run()
+
+    def stop(self) -> None:
+        """Stop the tray icon and shut down the Gradio server."""
+
+        self._stop_event.set()
+
+        if self._icon is not None:
+            with suppress(Exception):
+                self._icon.visible = False
+            with suppress(Exception):
+                self._icon.stop()
+
+        if self._server_handle is not None:
+            with suppress(Exception):
+                self._server_handle.close()
+
+
+def main(argv: Optional[Sequence[str]] = None) -> None:
+    """Launch the Gradio server with a companion system tray icon."""
+
+    if PYSTRAY_IMPORT_ERROR is not None:  # pragma: no cover - import-time guard
+        raise RuntimeError(
+            "System tray mode requires the 'pystray' dependency. Install it with "
+            "`pip install pystray` or `pip install talks-reducer[dev]` and try again."
+        ) from PYSTRAY_IMPORT_ERROR
+
+    parser = argparse.ArgumentParser(
+        description="Launch the Talks Reducer server with a system tray icon."
+    )
+    parser.add_argument(
+        "--host", dest="host", default=None, help="Custom host to bind."
+    )
+    parser.add_argument(
+        "--port",
+        dest="port",
+        type=int,
+        default=9005,
+        help="Port number for the web server (default: 9005).",
+    )
+    parser.add_argument(
+        "--share",
+        action="store_true",
+        help="Create a temporary public Gradio link.",
+    )
+    parser.add_argument(
+        "--no-browser",
+        action="store_true",
+        help="Do not automatically open the browser window.",
+    )
+
+    args = parser.parse_args(argv)
+
+    app = _ServerTrayApplication(
+        host=args.host,
+        port=args.port,
+        share=args.share,
+        open_browser=not args.no_browser,
+    )
+
+    atexit.register(app.stop)
+
+    try:
+        app.run()
+    except KeyboardInterrupt:  # pragma: no cover - interactive convenience
+        app.stop()
+
+
+__all__ = ["main"]
+
+
+if __name__ == "__main__":  # pragma: no cover - convenience entry point
+    main()

--- a/talks_reducer/server_tray.py
+++ b/talks_reducer/server_tray.py
@@ -91,12 +91,14 @@ class _ServerTrayApplication:
         share: bool,
         open_browser: bool,
         tray_mode: str,
+        open_gui: bool,
     ) -> None:
         self._host = host
         self._port = port
         self._share = share
         self._open_browser_on_start = open_browser
         self._tray_mode = tray_mode
+        self._open_gui_on_start = open_gui
 
         self._stop_event = threading.Event()
         self._ready_event = threading.Event()
@@ -247,6 +249,9 @@ class _ServerTrayApplication:
         if self._open_browser_on_start:
             self._handle_open_webui()
 
+        if self._open_gui_on_start:
+            self._launch_gui()
+
         if self._tray_mode == "headless":
             LOGGER.warning(
                 "Tray icon disabled (tray_mode=headless); press Ctrl+C to stop the server."
@@ -372,6 +377,20 @@ def main(argv: Optional[Sequence[str]] = None) -> None:
             "pystray worker, or disable the tray entirely."
         ),
     )
+    gui_group = parser.add_mutually_exclusive_group()
+    gui_group.add_argument(
+        "--open-gui",
+        dest="open_gui",
+        action="store_true",
+        help="Launch the Talks Reducer desktop GUI after startup (default).",
+    )
+    gui_group.add_argument(
+        "--no-gui",
+        dest="open_gui",
+        action="store_false",
+        help="Skip launching the desktop GUI automatically.",
+    )
+    parser.set_defaults(open_gui=True)
     parser.add_argument(
         "--debug",
         action="store_true",
@@ -398,6 +417,7 @@ def main(argv: Optional[Sequence[str]] = None) -> None:
         share=args.share,
         open_browser=args.open_browser,
         tray_mode=args.tray_mode,
+        open_gui=args.open_gui,
     )
 
     atexit.register(app.stop)

--- a/talks_reducer/server_tray.py
+++ b/talks_reducer/server_tray.py
@@ -157,6 +157,8 @@ class _ServerTrayApplication:
         if url:
             webbrowser.open(url)
             LOGGER.debug("Opened browser to %s", url)
+        else:
+            LOGGER.warning("Server URL not yet available; please try again.")
 
     def _handle_quit(
         self,
@@ -198,7 +200,11 @@ class _ServerTrayApplication:
 
         icon_image = _load_icon()
         menu = pystray.Menu(
-            pystray.MenuItem("Open Talks Reducer", self._handle_open),
+            pystray.MenuItem(
+                "Open WebUI",
+                self._handle_open,
+                default=True,
+            ),
             pystray.MenuItem("Quit", self._handle_quit),
         )
         self._icon = pystray.Icon(


### PR DESCRIPTION
## Summary
- add a Gradio system tray launcher with a CLI entry point and VS Code debug profile
- enable the Small video preset by default in the web UI and document the change
- declare the new pystray dependency needed for the tray icon

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68e578cd0a54832c887593077f6212cd