### PR TITLE
Support launching server tray from GUI executable

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,10 @@ Want the server to live in your system tray instead of a terminal window? Use:
 talks-reducer server-tray
 ```
 
+Bundled Windows builds include the same behaviour: run
+`talks-reducer.exe --server` to launch the tray-managed server directly from the
+desktop shortcut without opening the GUI first.
+
 Pass `--debug` to print verbose logs about the tray icon lifecycle, and
 `--tray-mode pystray-detached` to try pystray's alternate detached runner. If
 the icon backend refuses to appear, fall back to `--tray-mode headless` to keep

--- a/talks_reducer/gui.py
+++ b/talks_reducer/gui.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import argparse
+import importlib
 import json
 import os
 import re
@@ -1526,9 +1527,20 @@ def main(argv: Optional[Sequence[str]] = None) -> bool:
         action="store_true",
         help="Do not start the Talks Reducer server tray alongside the GUI.",
     )
+    parser.add_argument(
+        "--server",
+        action="store_true",
+        help="Launch the Talks Reducer server tray instead of the desktop GUI.",
+    )
 
     parsed_args, remaining = parser.parse_known_args(argv)
     no_tray = parsed_args.no_tray
+    if parsed_args.server:
+        package_name = __package__ or "talks_reducer"
+        tray_module = importlib.import_module(f"{package_name}.server_tray")
+        tray_main = getattr(tray_module, "main")
+        tray_main(remaining)
+        return False
     argv = remaining
 
     if argv:


### PR DESCRIPTION
## Summary
- add a --server flag to the GUI entrypoint that launches the system tray server helper
- document the Windows packaged shortcut for starting the tray-managed server

## Testing
- isort talks_reducer/gui.py
- black talks_reducer/gui.py

------
https://chatgpt.com/codex/tasks/task_e_68e64312ccdc832c8537fc7468ec9211