### PR TITLE
Add remote server selection and discovery support

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,14 @@ Example CLI usage:
 talks-reducer --small input.mp4
 ```
 
+Need to offload work to a remote Talks Reducer server? Pass `--url` with the
+server address and the CLI will upload the input, wait for processing to finish,
+and download the rendered video:
+
+```sh
+talks-reducer --url http://localhost:9005 demo.mp4
+```
+
 ### Speech detection
 
 Talks Reducer now relies on its built-in volume thresholding to detect speech. Adjust `--silent_threshold` if you need to fine-tune when segments count as silence. Dropping the optional Silero VAD integration keeps the install lightweight and avoids pulling in PyTorch.
@@ -86,6 +94,12 @@ launch as soon as the server is ready.
 This opens a local web page featuring a drag-and-drop upload zone, a **Small video** checkbox that mirrors the CLI preset, a live
 progress indicator, and automatic previews of the processed output. Once the job completes you can inspect the resulting compression
 ratio and download the rendered video directly from the page.
+
+The desktop GUI mirrors this behaviour. Open **Advanced** settings to provide a
+server URL and click **Discover** to scan your local network for Talks Reducer
+instances listening on port `9005`. Leaving the field blank keeps processing
+local; selecting a discovered server delegates rendering to that machine while
+the GUI downloads the finished files automatically.
 
 ### Uploading and retrieving a processed video
 

--- a/talks_reducer/discovery.py
+++ b/talks_reducer/discovery.py
@@ -1,0 +1,119 @@
+"""Utilities for discovering Talks Reducer servers on the local network."""
+
+from __future__ import annotations
+
+import ipaddress
+import socket
+from concurrent.futures import ThreadPoolExecutor
+from contextlib import closing
+from http.client import HTTPConnection
+from typing import Iterable, Iterator, List, Optional, Set
+
+DEFAULT_PORT = 9005
+DEFAULT_TIMEOUT = 0.4
+
+
+def _iter_local_ipv4_addresses() -> Iterator[str]:
+    """Yield IPv4 addresses that belong to the local machine."""
+
+    seen: Set[str] = set()
+
+    try:
+        hostname = socket.gethostname()
+        for info in socket.getaddrinfo(hostname, None, family=socket.AF_INET):
+            address = info[4][0]
+            if address and address not in seen:
+                seen.add(address)
+                yield address
+    except socket.gaierror:
+        pass
+
+    for probe in ("8.8.8.8", "1.1.1.1"):
+        try:
+            with closing(socket.socket(socket.AF_INET, socket.SOCK_DGRAM)) as sock:
+                sock.connect((probe, 80))
+                address = sock.getsockname()[0]
+                if address and address not in seen:
+                    seen.add(address)
+                    yield address
+        except OSError:
+            continue
+
+
+def _build_default_host_candidates(prefix_length: int = 24) -> List[str]:
+    """Return a list of host candidates based on detected local networks."""
+
+    hosts: Set[str] = {"127.0.0.1", "localhost"}
+
+    for address in _iter_local_ipv4_addresses():
+        hosts.add(address)
+        try:
+            network = ipaddress.ip_network(f"{address}/{prefix_length}", strict=False)
+        except ValueError:
+            continue
+        for host in network.hosts():
+            hosts.add(str(host))
+
+    return sorted(hosts)
+
+
+def _probe_host(host: str, port: int, timeout: float) -> Optional[str]:
+    """Return the URL if *host* responds on *port* within *timeout* seconds."""
+
+    connection: Optional[HTTPConnection] = None
+    try:
+        connection = HTTPConnection(host, port, timeout=timeout)
+        connection.request(
+            "GET", "/", headers={"User-Agent": "talks-reducer-discovery"}
+        )
+        response = connection.getresponse()
+        # Drain the response to avoid ResourceWarning in some Python versions.
+        response.read()
+        if 200 <= response.status < 500:
+            return f"http://{host}:{port}/"
+    except OSError:
+        return None
+    finally:
+        if connection is not None:
+            try:
+                connection.close()
+            except Exception:
+                pass
+    return None
+
+
+def discover_servers(
+    *,
+    port: int = DEFAULT_PORT,
+    timeout: float = DEFAULT_TIMEOUT,
+    hosts: Optional[Iterable[str]] = None,
+) -> List[str]:
+    """Scan *hosts* for running Talks Reducer servers on *port*.
+
+    When *hosts* is omitted, the local /24 networks derived from available IPv4
+    addresses are scanned. ``localhost`` and ``127.0.0.1`` are always included.
+    The function returns a sorted list of unique base URLs.
+    """
+
+    if hosts is None:
+        candidates = _build_default_host_candidates()
+    else:
+        candidates = sorted(set(hosts))
+        if "127.0.0.1" not in candidates:
+            candidates.append("127.0.0.1")
+        if "localhost" not in candidates:
+            candidates.append("localhost")
+
+    results: List[str] = []
+
+    with ThreadPoolExecutor(max_workers=32) as executor:
+        for url in executor.map(
+            lambda host: _probe_host(host, port, timeout), candidates
+        ):
+            if url and url not in results:
+                results.append(url)
+
+    return results
+
+
+__all__ = ["discover_servers"]

--- a/talks_reducer/server.py
+++ b/talks_reducer/server.py
@@ -309,7 +309,7 @@ def main(argv: Optional[Sequence[str]] = None) -> None:
 
     parser = argparse.ArgumentParser(description="Launch the Talks Reducer web UI.")
     parser.add_argument(
-        "--host", dest="host", default=None, help="Custom host to bind."
+        "--host", dest="host", default="0.0.0.0", help="Custom host to bind."
     )
     parser.add_argument(
         "--port",

--- a/talks_reducer/server_tray.py
+++ b/talks_reducer/server_tray.py
@@ -35,7 +35,7 @@ def _guess_local_url(host: Optional[str], port: int) -> str:
     """Return the URL the server is most likely reachable at locally."""
 
     if host in (None, "", "0.0.0.0", "::"):
-        hostname = "127.0.0.1"
+        hostname = "0.0.0.0"
     else:
         hostname = host
     return f"http://{hostname}:{port}/"

--- a/tests/test_discovery.py
+++ b/tests/test_discovery.py
@@ -1,0 +1,52 @@
+"""Tests for the network discovery helper utilities."""
+
+from __future__ import annotations
+
+import http.server
+import threading
+from contextlib import contextmanager
+
+from talks_reducer import discovery
+
+
+@contextmanager
+def _http_server() -> tuple[str, int]:
+    """Start a lightweight HTTP server for discovery tests."""
+
+    class Handler(http.server.BaseHTTPRequestHandler):
+        def do_GET(self) -> None:  # pragma: no cover - exercised via discovery
+            self.send_response(200)
+            self.end_headers()
+            self.wfile.write(b"OK")
+
+        def log_message(self, *args, **kwargs):  # type: ignore[override]
+            return
+
+    server = http.server.ThreadingHTTPServer(("127.0.0.1", 0), Handler)
+    host, port = server.server_address
+
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+
+    try:
+        yield host, port
+    finally:
+        server.shutdown()
+        thread.join(timeout=2)
+
+
+def test_discover_servers_detects_running_instance() -> None:
+    """The discovery helper should report a reachable local server."""
+
+    with _http_server() as (host, port):
+        results = discovery.discover_servers(port=port, hosts=[host])
+
+    expected_url = f"http://{host}:{port}/"
+    assert expected_url in results
+
+
+def test_discover_servers_handles_missing_hosts() -> None:
+    """Scanning an unreachable host should return an empty result list."""
+
+    results = discovery.discover_servers(port=65500, hosts=["192.0.2.123"])
+    assert results == []


### PR DESCRIPTION
## Summary
- add a --url CLI option that uploads files to a selected Talks Reducer server and downloads results
- add network discovery utilities and integrate the GUI advanced settings with a server URL field and Discover button
- document the remote workflow and cover discovery logic with automated tests

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68e64c7530b4832c8498fbf96266b0b2