### PR TITLE
Fix talks-reducer --server flag launching tray helper

### DIFF
--- a/talks_reducer/cli.py
+++ b/talks_reducer/cli.py
@@ -246,6 +246,22 @@ def _launch_server(argv: Sequence[str]) -> bool:
     return True
 
 
+def _launch_server_tray(argv: Sequence[str]) -> bool:
+    """Attempt to launch the server tray helper with the provided arguments."""
+
+    try:
+        tray_module = import_module(".server_tray", __package__)
+    except ImportError:
+        return False
+
+    tray_main = getattr(tray_module, "main", None)
+    if tray_main is None:
+        return False
+
+    tray_main(list(argv))
+    return True
+
+
 def main(argv: Optional[Sequence[str]] = None) -> None:
     """Entry point for the command line interface.
 
@@ -256,6 +272,14 @@ def main(argv: Optional[Sequence[str]] = None) -> None:
         argv_list = sys.argv[1:]
     else:
         argv_list = list(argv)
+
+    if "--server" in argv_list:
+        index = argv_list.index("--server")
+        tray_args = argv_list[index + 1 :]
+        if not _launch_server_tray(tray_args):
+            print("Server tray mode is unavailable.", file=sys.stderr)
+            sys.exit(1)
+        return
 
     if argv_list and argv_list[0] in {"server", "serve"}:
         if not _launch_server(argv_list[1:]):

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -96,6 +96,25 @@ def test_main_launches_server_when_requested(monkeypatch: pytest.MonkeyPatch) ->
     assert server_calls == [["--share"]]
 
 
+def test_main_launches_server_tray_when_flag_set(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The --server flag should launch the tray helper and skip CLI parsing."""
+
+    tray_calls: list[list[str]] = []
+
+    def fake_tray(argv: list[str]) -> bool:
+        tray_calls.append(list(argv))
+        return True
+
+    monkeypatch.setattr(cli, "_launch_server_tray", fake_tray)
+    monkeypatch.setattr(cli, "_launch_gui", lambda argv: False)
+
+    cli.main(["--server", "--tray-mode", "headless"])
+
+    assert tray_calls == [["--tray-mode", "headless"]]
+
+
 def test_main_exits_when_server_unavailable(monkeypatch: pytest.MonkeyPatch) -> None:
     """A missing Gradio server should raise SystemExit to mimic CLI failures."""
 


### PR DESCRIPTION
## Summary
- dispatch the talks-reducer CLI --server flag to the tray launcher instead of the video pipeline
- add unit coverage to ensure the tray helper is invoked with the provided arguments

## Testing
- pytest tests/test_cli.py

------
https://chatgpt.com/codex/tasks/task_e_68e680deee1c832c90a5924a80698084