### PR TITLE
ci: publish to PyPI on tagged releases

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -192,3 +192,34 @@ jobs:
         with:
           name: talks-reducer-inno-installer
           path: dist/*.exe
+
+  pypi-publish:
+    runs-on: ubuntu-latest
+    needs: test
+    if: startsWith(github.ref, 'refs/tags/')
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: "3.11"
+
+      - name: Install build dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install build twine
+
+      - name: Build distributions
+        run: python -m build
+
+      - name: Check distributions
+        run: python -m twine check dist/*
+
+      - name: Publish to PyPI
+        env:
+          TWINE_USERNAME: __token__
+          TWINE_PASSWORD: ${{ secrets.PYPI_API_TOKEN }}
+        run: python -m twine upload --non-interactive dist/*


### PR DESCRIPTION
## Summary
Adds a `pypi-publish` job to `.github/workflows/ci.yml` so tagging a release publishes to PyPI automatically, instead of the manual `scripts/deploy.py` run used until now.

- Runs only on tag pushes (`if: startsWith(github.ref, 'refs/tags/')`), gated on the `test` job passing.
- Builds the sdist + wheel, runs `twine check`, then `twine upload`.
- Authenticates with the `PYPI_API_TOKEN` secret via twine's `__token__` username.

It does not depend on the slow PyInstaller/Inno binary jobs, mirroring the manual deploy flow (PyPI publishing is independent of the desktop binaries).

## Verification
- YAML validated locally; the new job parses with the expected steps.
- Full end-to-end run only triggers on the next version tag. If a tag's version already exists on PyPI, `twine upload` fails — bump the version before tagging (the existing release flow already does).

🤖 Generated with [Claude Code](https://claude.com/claude-code)