### PR TITLE
fix: Bundle the gradio server stack so the tray server works in frozen builds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,7 +47,9 @@ jobs:
           - macos-latest
     runs-on: ${{ matrix.os }}
     needs: test
-    if: startsWith(github.ref, 'refs/tags/')
+    # Build on tags (for releases) and on pull requests so the frozen GUI can be
+    # downloaded and verified from the PR's artifacts before cutting a release.
+    if: startsWith(github.ref, 'refs/tags/') || github.event_name == 'pull_request'
 
     steps:
       - name: Check out repository

--- a/talks-reducer.spec
+++ b/talks-reducer.spec
@@ -129,10 +129,27 @@ def _collect_tcl_tk_data() -> list[tuple[str, str]]:
 if sys.platform == "darwin":
     datas.extend(_collect_tcl_tk_data())
 
-try:
-    datas.extend(collect_data_files("gradio_client"))
-except Exception:
-    pass
+# The "Run as server in tray" feature imports the full gradio server stack, not
+# just gradio_client (used by the GUI's remote mode). These packages ship runtime
+# data files that PyInstaller's module analysis does not pick up:
+#   * gradio's frontend templates plus ``package.json`` (read for its version),
+#   * ``safehttpx``/``groovy`` ``version.txt`` markers, which are read at import
+#     time and raise ``FileNotFoundError`` when missing, and
+#   * gradio and gradio_client read their own ``.py`` source files from disk at
+#     runtime (e.g. ``gradio/blocks_events.py`` for API introspection), so those
+#     modules must also be materialised as data files, not only frozen into the
+#     PYZ archive.
+# Collect everything so the bundled server can import and launch.
+for _pkg in ("gradio", "gradio_client"):
+    try:
+        datas.extend(collect_data_files(_pkg, include_py_files=True))
+    except Exception:
+        pass
+for _pkg in ("safehttpx", "groovy"):
+    try:
+        datas.extend(collect_data_files(_pkg))
+    except Exception:
+        pass
 
 hiddenimports = ["tkinterdnd2"]
 hiddenimports.extend(collect_submodules("talks_reducer"))
@@ -144,7 +161,10 @@ hiddenimports.extend(collect_submodules("talks_reducer"))
 hiddenimports.append("talks_reducer.server_tray")
 # gradio_client is imported lazily via importlib in the GUI, and fsspec loads
 # backend modules through plugin discovery. Collect both explicitly so remote
-# mode works in the PyInstaller bundle.
+# mode works in the PyInstaller bundle. (The full gradio package's modules are
+# already pulled in by ``talks_reducer.server``'s static ``import gradio``;
+# collecting all of its submodules here drags in ``backports`` shims that clash
+# with the excludes below, so only its data files are collected, above.)
 for _pkg in ("gradio_client", "fsspec", "pystray"):
     try:
         hiddenimports.extend(collect_submodules(_pkg))
@@ -155,7 +175,6 @@ DEFAULT_EXCLUDES = [
     "PySide6",
     "PyQt5",
     "PyQt6",
-    "pandas",
     "matplotlib",
     "numba",
     "cupy",


### PR DESCRIPTION
## Problem

\"Run as server in tray\" (#143) is non-functional in the frozen desktop app. After 0.19.1 stopped the stale-preference crash from bricking the launcher, enabling tray mode still produced **no tray icon** — the server silently fell back to the plain GUI.

Root cause: the PyInstaller bundle ships the gradio server *modules* but not the runtime files the gradio server needs. The `import gradio` → `talks_reducer.server` chain fails in the bundle, layer by layer:

1. `safehttpx/version.txt` & `groovy/version.txt` missing → `FileNotFoundError` at import
2. gradio frontend templates / `package.json` missing
3. `No module named 'pandas'` — gradio imports pandas, but it was in the spec `excludes`
4. `FileNotFoundError: gradio/blocks_events.py` — gradio reads its own `.py` sources from disk at runtime (API introspection)

## Fix (`talks-reducer.spec`)

- `collect_data_files("gradio"/"gradio_client", include_py_files=True)` — bundles templates **and** the `.py` sources gradio reads at runtime
- `collect_data_files("safehttpx"/"groovy")` — bundles the `version.txt` markers
- Remove `pandas` from `excludes` (gradio imports it unconditionally)

`matplotlib`/torch/etc. stay excluded — an import trace showed `pandas` is the only excluded module the gradio/server_tray chain needs, and the server binds its port without matplotlib.

## Verification

Rebuilt the macOS `.app` from this spec and confirmed it **cold-starts into tray mode**: Gradio server bound on `:9005`, server-managed GUI child with the **Server:** label + Connected clients panel, and the monochrome tray icon running. Bundle size ~+20 MB (pandas + gradio sources/templates).

## CI change

The `pyinstaller` build job now also runs on pull requests (previously tag-only) so the frozen `.app` can be downloaded from this PR's artifacts and checked before cutting a release. Release / installer / Homebrew / PyPI jobs remain tag-only.

## Notes / not addressed here

- Local end-to-end build used a Homebrew Python with **Tk 9.0**; drag-and-drop and ttk checkbox rendering look off there only because tkinterdnd2's `tkdnd` is built for **Tk 8.6**. CI builds against Tk 8.6, so those are not real issues in the release.
- `matplotlib` stays excluded; if a gradio route needs it at runtime, dropping it from `excludes` is the follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)