### PR TITLE
fix: Minor GUI, cancel, and installer fixes

### DIFF
--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -1,7 +1,5 @@
 # TODO
 
-- [x] Add "mp3" option to the codec selector; when selected, save the result as an mp3 file
-- [x] Make menu bar icon on macOS monochrome
-- [x] Launch the macOS app in `server-tray` mode from the regular app icon (not the terminal): add a setting in the main app to enable server mode and minimize to the tray, so it no longer requires the pip CLI command
-- [x] Make the web UI PWA-ready: it is already installable (Gradio auto-serves `/manifest.json`), but the manifest still points at the default Gradio logo (`static/img/logo_nosize.svg`). Override `/manifest.json` (and apple-touch icons) to serve the app's own icon from `talks_reducer/resources` so the installed PWA shows the Talks Reducer icon instead of the Gradio one
-- [x] Add update system on macOS
+- [ ] Добавить быструю отмену во время remote upload
+- [ ] Убрать ссылку Download portable из Check updates
+- [ ] Убрать из инсталлера галочку "Register in context menu", default unchecked

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -1,5 +1,5 @@
 # TODO
 
-- [ ] Добавить быструю отмену во время remote upload
-- [ ] Убрать ссылку Download portable из Check updates
-- [ ] Убрать из инсталлера галочку "Register in context menu", default unchecked
+- [x] Добавить быструю отмену во время remote upload
+- [x] Убрать ссылку Download portable из Check updates
+- [x] Убрать из инсталлера галочку "Register in context menu", default unchecked

--- a/scripts/talks-reducer-installer.iss
+++ b/scripts/talks-reducer-installer.iss
@@ -69,7 +69,7 @@ Name: "english"; MessagesFile: "compiler:Default.isl"
 
 [Tasks]
 Name: "desktopicon"; Description: "{cm:CreateDesktopIcon}"; GroupDescription: "Additional shortcuts:"; Flags: unchecked
-Name: "addcontext"; Description: "Register ""Open with Talks Reducer"" in Explorer"; GroupDescription: "Shell integration:"
+Name: "addcontext"; Description: "Register ""Open with Talks Reducer"" in Explorer"; GroupDescription: "Shell integration:"; Flags: unchecked
 
 [Files]
 Source: "{#SOURCE_DIR}*"; DestDir: "{app}"; Flags: recursesubdirs createallsubdirs ignoreversion

--- a/talks_reducer/audio.py
+++ b/talks_reducer/audio.py
@@ -122,6 +122,7 @@ def process_audio_chunks(
     *,
     batch_size: int = 10,
     progress_callback: Optional[Callable[[int], None]] = None,
+    check_stop: Optional[Callable[[], None]] = None,
 ) -> Tuple[np.ndarray, List[List[int]]]:
     """Return processed audio and updated chunk timings for the provided chunk list.
 
@@ -129,6 +130,11 @@ def process_audio_chunks(
     with the number of source audio samples that chunk consumed. The reported
     increment is never negative, so zero-length chunks contribute ``0`` rather
     than a negative count.
+
+    When ``check_stop`` is provided it is invoked once per chunk before the
+    blocking phase-vocoder pass; the callback is expected to raise when the user
+    requested a stop, so cancellation is honored within a single chunk instead of
+    only after the whole audio stage completes.
     """
 
     audio_buffers: List[np.ndarray] = []
@@ -141,6 +147,8 @@ def process_audio_chunks(
         batch_audio: List[np.ndarray] = []
 
         for chunk in batch_chunks:
+            if check_stop is not None:
+                check_stop()
             start = int(chunk[0] * samples_per_frame)
             end = int(chunk[1] * samples_per_frame)
             audio_chunk = audio_data[start:end]

--- a/talks_reducer/gui/app.py
+++ b/talks_reducer/gui/app.py
@@ -198,6 +198,12 @@ class TalksReducerGUI:
         else:
             self.root = tk.Tk()
 
+        # Hide the window while the layout is built and sized. Tk otherwise maps
+        # the window at its tiny default size and only resizes to the requested
+        # geometry once ``apply_window_size`` runs, producing a visible size flash
+        # on launch. It is revealed via ``deiconify`` at the end of ``__init__``.
+        self.root.withdraw()
+
         # Set window title with version information
         app_version = resolve_version()
         if app_version and app_version != "unknown":
@@ -209,7 +215,16 @@ class TalksReducerGUI:
 
         self._full_size = (1200, 900)
         self._simple_size = (470, 300)
-        # self.root.geometry(f"{self._full_size[0]}x{self._full_size[1]}")
+        # Seed the window geometry from the persisted Simple mode preference
+        # *before* building the layout so the window opens at its final size
+        # instead of snapping to the natural content size and then jumping once
+        # ``apply_window_size`` runs. ``simple_mode_var`` does not exist yet, so
+        # read the stored value directly (default True, matching the var below).
+        initial_simple = self.preferences.get("simple_mode", True)
+        initial_width, initial_height = (
+            self._simple_size if initial_simple else self._full_size
+        )
+        self.root.geometry(f"{initial_width}x{initial_height}")
         self.style = self.ttk.Style(self.root)
 
         self._processing_thread: Optional[threading.Thread] = None
@@ -401,6 +416,10 @@ class TalksReducerGUI:
         if self.server_managed:
             self.root.protocol("WM_DELETE_WINDOW", self._on_close)
             self._start_activity_log()
+
+        # Reveal the window now that the layout is built and the geometry is
+        # finalized, so it appears directly at its final size without a flash.
+        self.root.deiconify()
 
     def _start_run(self) -> None:
         if self._processing_thread and self._processing_thread.is_alive():

--- a/talks_reducer/gui/app.py
+++ b/talks_reducer/gui/app.py
@@ -263,7 +263,6 @@ class TalksReducerGUI:
         self._download_thread: Optional[threading.Thread] = None
         self._latest_version: Optional[str] = None
         self._installer_url: Optional[str] = None
-        self._portable_url: Optional[str] = None
         self._update_link_labels: List[Any] = []
 
         self.input_files: List[str] = []
@@ -892,10 +891,9 @@ class TalksReducerGUI:
 
                 if is_newer:
                     installer_url = update_checker.get_installer_url(latest_version)
-                    portable_url = update_checker.get_portable_url(latest_version)
                     self._schedule_on_ui_thread(
                         lambda: self._on_update_check_complete(
-                            latest_version, None, installer_url, portable_url
+                            latest_version, None, installer_url
                         )
                     )
                 else:
@@ -916,7 +914,6 @@ class TalksReducerGUI:
         latest_version: Optional[str],
         error: Optional[str],
         installer_url: Optional[str] = None,
-        portable_url: Optional[str] = None,
     ) -> None:
         """Handle update check completion."""
         if not hasattr(self, "check_updates_button"):
@@ -938,7 +935,6 @@ class TalksReducerGUI:
         if latest_version:
             self._latest_version = latest_version
             self._installer_url = installer_url
-            self._portable_url = portable_url
 
             presentation = update_checker.build_update_message(latest_version)
 
@@ -1054,7 +1050,6 @@ class TalksReducerGUI:
                 # Reset state
                 self._latest_version = None
                 self._installer_url = None
-                self._portable_url = None
             except Exception as exc:
                 self._clear_update_status()
                 self._set_update_status(f"Failed to launch installer: {str(exc)}")

--- a/talks_reducer/gui/update_checker.py
+++ b/talks_reducer/gui/update_checker.py
@@ -117,11 +117,6 @@ def get_installer_url(version: str) -> str:
     return f"https://github.com/popstas/talks-reducer/releases/download/v{version}/talks-reducer-{version}-setup.exe"
 
 
-def get_portable_url(version: str) -> str:
-    """Construct the portable download URL for the given version."""
-    return f"https://github.com/popstas/talks-reducer/releases/download/v{version}/talks-reducer-windows-{version}.zip"
-
-
 def get_macos_app_url(version: str) -> str:
     """Construct the macOS .app zip download URL for the given version."""
     return (
@@ -192,7 +187,6 @@ def build_update_message(
     return UpdatePresentation(
         status_text=f"New version {version} is available!",
         links=[
-            ("Download portable", get_portable_url(version)),
             ("Releases page", releases_url),
         ],
         button_text=f"Download {version}",

--- a/talks_reducer/pipeline.py
+++ b/talks_reducer/pipeline.py
@@ -457,6 +457,9 @@ def speed_up_video(
                 options.audio_fade_envelope_size,
                 max_audio_volume,
                 progress_callback=audio_task.advance,
+                check_stop=lambda: _raise_if_stopped(
+                    reporter, temp_path=job_temp_path, dependencies=dependencies
+                ),
             )
 
         audio_new_path = job_temp_path / "audioNew.wav"

--- a/talks_reducer/server.py
+++ b/talks_reducer/server.py
@@ -14,7 +14,7 @@ from contextlib import AbstractContextManager, suppress
 from dataclasses import dataclass
 from pathlib import Path
 from queue import SimpleQueue
-from threading import Lock, Thread
+from threading import Event, Lock, Thread
 from typing import Callable, Iterator, Optional, Sequence, cast
 
 import gradio as gr
@@ -22,7 +22,11 @@ import gradio as gr
 from talks_reducer.ffmpeg import FFmpegNotFoundError, is_global_ffmpeg_available
 from talks_reducer.icons import find_icon_path
 from talks_reducer.models import ProcessingOptions, ProcessingResult
-from talks_reducer.pipeline import _input_to_output_filename, speed_up_video
+from talks_reducer.pipeline import (
+    ProcessingAborted,
+    _input_to_output_filename,
+    speed_up_video,
+)
 from talks_reducer.progress import (
     CallbackProgressHandle,
     ProgressHandle,
@@ -76,6 +80,17 @@ class GradioProgressReporter(SignalProgressReporter):
         self._max_log_lines = max_log_lines
         self._active_desc = "Processing"
         self.logs: list[str] = []
+        self._stop_event = Event()
+
+    def stop_requested(self) -> bool:
+        """Return ``True`` once a client cancellation has requested a stop."""
+
+        return self._stop_event.is_set()
+
+    def request_stop(self) -> None:
+        """Signal the running pipeline to abort at its next stop check."""
+
+        self._stop_event.set()
 
     def log(self, message: str) -> None:
         """Collect log messages for display in the web interface."""
@@ -799,6 +814,10 @@ def run_pipeline_job(
     def _worker() -> None:
         try:
             result = speed_up(options, reporter=reporter)
+        except ProcessingAborted:
+            # A client cancellation tripped ``request_stop``; unwind quietly
+            # instead of surfacing a "Failed to process" error to the user.
+            reporter.log("Processing cancelled.")
         except FFmpegNotFoundError as exc:  # pragma: no cover - depends on runtime env
             _emit("error", gr.Error(str(exc)))
         except FileNotFoundError as exc:
@@ -827,6 +846,12 @@ def run_pipeline_job(
             yield (kind, payload)
     finally:
         if thread is not None:
+            # When the consumer stops early (gradio closing the generator on a
+            # client cancel), signal the worker to abort so ``join`` returns at
+            # the next stop check instead of blocking until the full job ends.
+            request_stop = getattr(reporter, "request_stop", None)
+            if callable(request_stop):
+                request_stop()
             thread.join()
 
 
@@ -1016,7 +1041,8 @@ def build_interface(concurrency_limit: int = 1) -> gr.Blocks:
     )
 
     with gr.Blocks(title=f"Talks Reducer Web UI{version_suffix}") as demo:
-        gr.Markdown(f"""
+        gr.Markdown(
+            f"""
             ## Talks Reducer Web UI{version_suffix}
             Drop a video into the zone below or click to browse. **Small video** is enabled
             by default to apply the 720p/128k preset before processing starts—clear it to
@@ -1028,7 +1054,8 @@ def build_interface(concurrency_limit: int = 1) -> gr.Blocks:
             bundled build lacks.
 
             Video will be rendered on server **{server_identity}**.
-            """.strip())
+            """.strip()
+        )
 
         with gr.Column():
             file_input = gr.File(

--- a/talks_reducer/service_client.py
+++ b/talks_reducer/service_client.py
@@ -210,12 +210,17 @@ def _install_transfer_progress(
     api_name: Optional[str],
     upload_total: Optional[int],
     progress_callback: Callable[[str, Optional[int], Optional[int], str], None],
+    should_cancel: Optional[Callable[[], bool]] = None,
 ) -> bool:
     """Patch the gradio endpoint to stream byte-level upload/download progress.
 
     Returns ``True`` when the endpoint was patched. Callers that receive
     ``False`` (for example because a stub client without real endpoints was
     supplied) should emit the synthetic upload-complete event themselves.
+
+    When *should_cancel* is supplied it is polled once per uploaded chunk so a
+    stop request aborts the in-flight upload within a single ~64 KiB chunk
+    instead of only after the whole file has been sent.
     """
 
     try:
@@ -246,6 +251,10 @@ def _install_transfer_progress(
 
         def _on_bytes(count: int) -> None:
             nonlocal sent
+            if should_cancel is not None and should_cancel():
+                # Raise mid-stream so httpx tears down the in-flight POST instead
+                # of finishing the upload before the cancel is noticed.
+                raise ProcessingAborted("Remote processing cancelled by user.")
             sent += count
             current = min(sent, upload_total) if upload_total else sent
             throttled("Uploading:", current, upload_total, "bytes")
@@ -545,6 +554,7 @@ def send_video(
             submit_kwargs.get("api_name"),
             upload_total,
             progress_callback,
+            should_cancel,
         )
 
     if job_factory is not None:

--- a/tests/test_audio.py
+++ b/tests/test_audio.py
@@ -181,6 +181,94 @@ def test_process_audio_chunks_reports_incremental_progress(
     assert all(value >= 0 for value in increments)
 
 
+def test_process_audio_chunks_check_stop_aborts_between_chunks(
+    synthetic_audio_samples, prepared_chunks, fake_phase_vocoder
+):
+    """A raising ``check_stop`` aborts before processing the whole chunk list."""
+
+    stereo_audio = synthetic_audio_samples["stereo"]
+    chunk_outputs = [
+        np.array([[1.0, 2.0]], dtype=np.float32),
+        np.array([[2.0, -2.0]], dtype=np.float32),
+    ]
+    fake_phase_vocoder(chunk_outputs)
+
+    class _Stop(Exception):
+        pass
+
+    calls = {"count": 0}
+    increments: list[int] = []
+
+    def check_stop() -> None:
+        calls["count"] += 1
+        if calls["count"] > 1:
+            raise _Stop()
+
+    with pytest.raises(_Stop):
+        audio.process_audio_chunks(
+            stereo_audio,
+            prepared_chunks,
+            samples_per_frame=2.0,
+            speeds=[1.0, 0.5],
+            audio_fade_envelope_size=2,
+            max_audio_volume=2.0,
+            progress_callback=increments.append,
+            check_stop=check_stop,
+        )
+
+    # The stop was checked before each chunk and aborted before the second one,
+    # so only the first chunk reported progress.
+    assert increments == [4]
+
+
+def test_process_audio_chunks_check_stop_noop_matches_default(
+    synthetic_audio_samples, prepared_chunks, fake_phase_vocoder
+):
+    """A non-raising ``check_stop`` leaves the processed output unchanged."""
+
+    stereo_audio = synthetic_audio_samples["stereo"]
+    chunk_outputs = [
+        np.array(
+            [
+                [1.0, 2.0],
+                [3.0, 4.0],
+                [5.0, 6.0],
+                [7.0, 8.0],
+            ],
+            dtype=np.float32,
+        ),
+        np.array([[2.0, -2.0]], dtype=np.float32),
+    ]
+
+    fake_phase_vocoder(chunk_outputs)
+
+    processed_audio, updated_chunks = audio.process_audio_chunks(
+        stereo_audio,
+        prepared_chunks,
+        samples_per_frame=2.0,
+        speeds=[1.0, 0.5],
+        audio_fade_envelope_size=2,
+        max_audio_volume=2.0,
+        check_stop=lambda: None,
+    )
+
+    # Identical to ``test_process_audio_chunks_applies_envelope_and_updates_timings``:
+    # a no-op ``check_stop`` must not alter the processed output or timings.
+    expected_audio = np.array(
+        [
+            [0.0, 0.0],
+            [0.75, 1.0],
+            [2.5, 3.0],
+            [1.75, 2.0],
+            [0.0, 0.0],
+        ],
+        dtype=np.float32,
+    )
+
+    np.testing.assert_allclose(processed_audio, expected_audio)
+    assert updated_chunks == [[0, 2, 0, 2], [2, 3, 2, 3], [3, 3, 3, 3]]
+
+
 def test_process_audio_chunks_progress_callback_not_called_for_empty():
     """Empty inputs should complete cleanly without invoking the callback."""
 

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -2,6 +2,8 @@ from __future__ import annotations
 
 import json
 import sys
+import threading
+import time
 from pathlib import Path
 from queue import SimpleQueue
 from typing import Iterator
@@ -139,6 +141,69 @@ def test_run_pipeline_job_wraps_exceptions_with_gradio_error(tmp_path: Path) -> 
     error = emitted[1][1]
     assert isinstance(error, gr.Error)
     assert "Failed to process the video" in str(error)
+
+
+def test_gradio_progress_reporter_stop_flag() -> None:
+    reporter = server.GradioProgressReporter()
+    assert reporter.stop_requested() is False
+    reporter.request_stop()
+    assert reporter.stop_requested() is True
+
+
+def test_run_pipeline_job_aborts_worker_on_early_close(tmp_path: Path) -> None:
+    """Closing the generator early must trip ``request_stop`` and unwind the worker."""
+
+    input_file = tmp_path / "input.mp4"
+    output_file = tmp_path / "output.mp4"
+    temp_dir = tmp_path / "temp"
+    temp_dir.mkdir()
+    input_file.write_bytes(b"")
+
+    options = ProcessingOptions(
+        input_file=input_file,
+        output_file=output_file,
+        temp_folder=temp_dir,
+        small=False,
+    )
+
+    holder: dict[str, server.GradioProgressReporter] = {}
+    worker_finished = threading.Event()
+
+    def _factory(progress_callback, log_callback):
+        reporter = server.GradioProgressReporter(
+            progress_callback=progress_callback, log_callback=log_callback
+        )
+        holder["reporter"] = reporter
+        return reporter
+
+    def _speed_up(_options, reporter):
+        reporter.log("started")
+        try:
+            while not reporter.stop_requested():
+                time.sleep(0.01)
+            raise server.ProcessingAborted("cancelled")
+        finally:
+            worker_finished.set()
+
+    events = SimpleQueue()
+    event_stream = server.run_pipeline_job(
+        options,
+        speed_up=_speed_up,
+        reporter_factory=_factory,
+        events=events,
+        enable_progress=True,
+        start_in_thread=True,
+    )
+
+    # Prime the generator so the worker thread starts and emits its first log,
+    # then leave it blocked on the stop flag.
+    first_kind, _ = next(event_stream)
+    assert first_kind == "log"
+
+    event_stream.close()
+
+    assert holder["reporter"].stop_requested() is True
+    assert worker_finished.wait(1.0)
 
 
 def test_describe_server_host_prefers_hostname_and_ip(

--- a/tests/test_service_client.py
+++ b/tests/test_service_client.py
@@ -1099,6 +1099,76 @@ def test_install_transfer_progress_restores_httpx_on_error(monkeypatch, tmp_path
     assert service_client_module.httpx.stream is sentinel_stream
 
 
+def test_install_transfer_progress_cancels_upload_midstream(monkeypatch, tmp_path):
+    """A stop request aborts the upload mid-stream, not after it completes."""
+
+    upload_file = tmp_path / "input.mp4"
+    upload_file.write_bytes(b"0123456789")
+
+    class FakeEndpoint:
+        def _upload_file(self, file_obj, data_index=0):
+            with open(file_obj["path"], "rb") as handle:
+                service_client_module.httpx.post(
+                    "http://server/upload",
+                    files=[("files", ("input.mp4", handle))],
+                )
+            return {"path": "/server/input.mp4"}
+
+        def _download_file(self, payload):  # pragma: no cover - unused here
+            return b""
+
+    class FakeClient:
+        def __init__(self):
+            self.endpoints = {0: FakeEndpoint()}
+
+        def _infer_fn_index(self, api_name, fn_index):
+            return 0
+
+    import gradio_client.client as service_client_module
+
+    def fake_post(url, *args, files=None, **kwargs):
+        # httpx reads the wrapped file in 4-byte chunks while streaming the body.
+        for _field, spec in files:
+            handle = spec[1]
+            while handle.read(4):
+                pass
+        return SimpleNamespace(raise_for_status=lambda: None, json=lambda: ["/x"])
+
+    monkeypatch.setattr(service_client_module.httpx, "post", fake_post)
+
+    # Cancel only after the first chunk has streamed so we prove the abort lands
+    # mid-upload rather than once every byte was already sent.
+    calls = {"count": 0}
+
+    def should_cancel() -> bool:
+        calls["count"] += 1
+        return calls["count"] > 1
+
+    client = FakeClient()
+    events: list[tuple[str, Optional[int], Optional[int], str]] = []
+
+    installed = service_client._install_transfer_progress(
+        client,
+        "/process_video",
+        upload_file.stat().st_size,
+        lambda *args: events.append(args),
+        should_cancel,
+    )
+    assert installed is True
+
+    endpoint = client.endpoints[0]
+    with pytest.raises(service_client.ProcessingAborted):
+        endpoint._upload_file({"path": str(upload_file)})
+
+    upload_events = [event for event in events if event[0] == "Uploading:"]
+    # The first chunk streamed before the cancel; the terminal 100% event never
+    # fires because the upload was aborted.
+    assert ("Uploading:", 4, 10, "bytes") in upload_events
+    assert ("Uploading:", 10, 10, "bytes") not in upload_events
+    # The ``finally`` block must restore the patched httpx.post despite the raise.
+    assert service_client_module.httpx.post is fake_post
+
+
 def test_install_transfer_progress_skips_completion_on_upload_error(
     monkeypatch, tmp_path
 ):

--- a/tests/test_update_checker.py
+++ b/tests/test_update_checker.py
@@ -86,7 +86,6 @@ def test_build_update_message_windows() -> None:
     assert presentation.button_text == "Download 9.9.9"
     assert presentation.enable_download is True
     assert presentation.links == [
-        ("Download portable", update_checker.get_portable_url("9.9.9")),
         ("Releases page", update_checker.get_releases_page_url()),
     ]
 


### PR DESCRIPTION
## Summary

A batch of minor GUI, client, and installer fixes.

### Faster cancellation (remote upload + audio stage)
- Poll the cancel flag per uploaded chunk so **Stop** aborts an in-flight remote upload within one ~64 KiB chunk instead of only after the whole file is sent.
- Add a per-chunk stop check to the audio phase-vocoder loop (`process_audio_chunks`) so cancellation is honored within a single chunk, in both local and server processing.
- Give the server's `GradioProgressReporter` a `threading.Event`-backed stop signal that `run_pipeline_job` trips when the client cancels, so the server pipeline actually aborts mid-stage rather than running to completion.

### GUI: Check updates
- Remove the "Download portable" link from the update panel (installer download + Releases page remain); drop the now-dead `get_portable_url` helper and `_portable_url` plumbing.

### GUI: window launch
- Seed window geometry from the persisted Simple-mode preference and keep the window withdrawn until the layout is built, eliminating the visible size flash on launch.

### Windows installer
- Default the "Register 'Open with Talks Reducer' in Explorer" context-menu task to **unchecked** (opt-in), matching the desktop-icon task.

## Tests
- New coverage: mid-stream upload cancel, per-chunk audio stop, server reporter stop flag + early-generator-close abort, and the updated Check-updates link set.
- Full suite: 683 passed. The 10 `test_gui_layout.py` failures are pre-existing (a headless-tkinter environment issue) and unrelated to this branch.

## Manual verification checklist
- [ ] Remote mode: click **Stop** while `Uploading: NN%` — run aborts promptly.
- [ ] Remote mode: click **Stop** during `Audio processing:` — client returns to idle and the server console shows the pipeline aborting.
- [ ] Local mode: **Stop** during `Audio processing:` aborts within ~one chunk.
- [ ] Check updates panel shows only the Releases page link (no "Download portable").
- [ ] GUI launches with no window-size flash.
- [ ] Installer's context-menu task is unchecked by default.
